### PR TITLE
Rw editorial2

### DIFF
--- a/draft-ietf-core-sid.md
+++ b/draft-ietf-core-sid.md
@@ -265,7 +265,7 @@ module ietf-sid-file {
     "IETF Core Working Group";
 
   contact
-    "WG Web:   <http://datatracker.ietf.org/wg/core/>
+    "WG Web:   <https://datatracker.ietf.org/wg/core/>
 
      WG List:  <mailto:core@ietf.org>
 
@@ -1333,8 +1333,8 @@ Registry" as defined in {{ietf-iana-sid-range-allocation}}. For the other YANG
 modules, the authors can acquire a SID range from any "YANG SID Range Registry" of
 their choice.
 
-Once the SID range is acquired, the owner can use it to generate ".sid" file/s
-for his YANG module/s.  It is recommended to leave some unallocated SIDs
+Once the SID range is acquired, owners can use it to generate ".sid" file/s
+for their YANG module/s.  It is recommended to leave some unallocated SIDs
 following the allocated range in each ".sid" file in order to allow better
 evolution of the YANG module in the future.  Generation of ".sid" files should
 be performed using an automated tool.  Note that ".sid" files can only be

--- a/draft-ietf-core-yang-cbor.md
+++ b/draft-ietf-core-yang-cbor.md
@@ -363,10 +363,11 @@ A1                                         # map(1)
 
 ## The 'container' and other nodes from the data tree {#container}
 
-Instances of containers, lists, notification contents, RPC inputs, RPC outputs, action inputs, and action outputs schema nodes MUST be encoded using a CBOR map data item (major type 5).
+Instances of containers, notification contents, RPC inputs, RPC outputs, action inputs, and action outputs schema nodes MUST be encoded using a CBOR map data item (major type 5).
+The same encoding is also used for the list entries in a list ({{list}}).
 A map consists of pairs of data items, with each pair consisting of a key and a value. Each key within the CBOR map is set to a schema node identifier, each value is set to the value of this schema node instance according to the instance datatype.
 
-This specification supports two types of CBOR keys; SID as defined in {{sid}} and names as defined in {{name}}.
+This specification supports two types of CBOR map keys; SID as defined in {{sid}} and names as defined in {{name}}.
 
 The following examples show the encoding of a 'system-state' container schema node instance using SIDs or names.
 
@@ -1270,7 +1271,8 @@ strings or adjacent integers are an error. An array with a single byte string
 MUST instead be encoded as just that byte string. An array with a single
 positive integer is an error.
 
-Values of 'bits' types defined in a 'union' type MUST be encoded using a
+To maintain compatibility with the encoding of overlapping unions in XML,
+values of 'bits' types defined in a 'union' type MUST be encoded using a
 CBOR text string data item (major type 3) and MUST contain a space-separated
 sequence of names of 'bits' that are set. The encoding MUST be enclosed by the
 bits CBOR tag as specified in {{tag-registry}}.


### PR DESCRIPTION
RW-editorial2: list entries, not lists; explain bits in unions.

Close #51.
