### PR TITLE
RFC9595: Note down text of a potential errata report about Example .sid File.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -5,6 +5,17 @@ e: ietf-system-from-csv.sid
 ietf-sid-file.yangtree: ietf-sid-file.yang
 	pyang ${PYANGPATH} -f tree --tree-print-structures --tree-line-length=70  ietf-sid-file.yang  > ietf-sid-file.yangtree
 
+# please install the correct version of PYANG
+# pip install git+https://github.com/core-wg/pyang.git@choice-case
+.PHONY: pyang-sid
+pyang-sid: ietf-system.yang
+	git checkout c95b9ca29665c9d1d4704edf59efe54a14a4a417 ./ietf-system.sid
+	# should work with python installed using pip, not pipx
+	# if you installed pyang using pipx, you may fallback to simply:
+	#  $ pyang --sid-update-fiel ietf-system.sid ietf-system.yang
+	python -m pyang --sid-update-file ietf-system.sid ietf-system.yang
+	cp ietf-system@2014-08-06.sid ietf-system.sid
+
 # gem install sid-csv to get the tool
 
 ietf-system.csv: ietf-system.sid

--- a/code/ietf-system.sid
+++ b/code/ietf-system.sid
@@ -410,7 +410,7 @@
         "sid": "1774"
       },
       {
-	"namespace": "data",
+        "namespace": "data",
         "identifier": "/ietf-system:set-current-datetime/output",
         "status": "unstable",
         "sid": "1716"

--- a/code/ietf-system.sid
+++ b/code/ietf-system.sid
@@ -2,13 +2,12 @@
   "ietf-sid-file:sid-file": {
     "module-name": "ietf-system",
     "module-revision": "2014-08-06",
-    "sid-file-version": 1,
-    "sid-file-status": "unpublished",
+    "sid-file-version": "1",
     "description": "Example sid file",
     "dependency-revision": [
       {
-        "module-name": "iana-crypt-hash",
-        "module-revision": "2014-08-06"
+        "module-name": "ietf-yang-types",
+        "module-revision": "2013-07-15"
       },
       {
         "module-name": "ietf-inet-types",
@@ -19,8 +18,8 @@
         "module-revision": "2018-02-14"
       },
       {
-        "module-name": "ietf-yang-types",
-        "module-revision": "2013-07-15"
+        "module-name": "iana-crypt-hash",
+        "module-revision": "2014-08-06"
       }
     ],
     "assignment-range": [
@@ -112,9 +111,13 @@
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:set-current-datetime/output",
-        "status": "unstable",
-        "sid": "1716"
+        "identifier": "/ietf-system:set-current-datetime/input",
+        "sid": "1775"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:set-current-datetime/input/current-datetime",
+        "sid": "1776"
       },
       {
         "namespace": "data",
@@ -405,6 +408,12 @@
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/server/udp/shared-secret",
         "sid": "1774"
+      },
+      {
+	"namespace": "data",
+        "identifier": "/ietf-system:set-current-datetime/output",
+        "status": "unstable",
+        "sid": "1716"
       },
       {
         "namespace": "data",

--- a/code/ietf-system.sid
+++ b/code/ietf-system.sid
@@ -111,302 +111,404 @@
       {
         "namespace": "data",
         "identifier": "/ietf-system:set-current-datetime/input",
-        "sid": "1775"
+        "sid": "1716"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:set-current-datetime/input/current-datetime",
-        "sid": "1776"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system",
+        "identifier": "/ietf-system:set-current-datetime/input/\
+                                                   current-datetime",
         "sid": "1717"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-restart",
+        "identifier": "/ietf-system:set-current-datetime/output",
         "sid": "1718"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-shutdown",
+        "identifier": "/ietf-system:system",
         "sid": "1719"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state",
+        "identifier": "/ietf-system:system-restart",
         "sid": "1720"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/clock",
+        "identifier": "/ietf-system:system-restart/input",
         "sid": "1721"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/clock/boot-datetime",
+        "identifier": "/ietf-system:system-restart/output",
         "sid": "1722"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/clock/current-datetime",
+        "identifier": "/ietf-system:system-shutdown",
         "sid": "1723"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform",
+        "identifier": "/ietf-system:system-shutdown/input",
         "sid": "1724"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/machine",
+        "identifier": "/ietf-system:system-shutdown/output",
         "sid": "1725"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/os-name",
+        "identifier": "/ietf-system:system-state",
         "sid": "1726"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/os-release",
+        "identifier": "/ietf-system:system-state/clock",
         "sid": "1727"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/os-version",
+        "identifier": "/ietf-system:system-state/clock/boot-datetime\
+                                                                   ",
         "sid": "1728"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication",
+        "identifier": "/ietf-system:system-state/clock/current-\
+                                                           datetime",
         "sid": "1729"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user",
+        "identifier": "/ietf-system:system-state/platform",
         "sid": "1730"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user-authentication-order",
+        "identifier": "/ietf-system:system-state/platform/machine",
         "sid": "1731"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/authorized-key",
+        "identifier": "/ietf-system:system-state/platform/os-name",
         "sid": "1732"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/authorized-key/algorithm",
+        "identifier": "/ietf-system:system-state/platform/os-release\
+                                                                   ",
         "sid": "1733"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/authorized-key/key-data",
+        "identifier": "/ietf-system:system-state/platform/os-version\
+                                                                   ",
         "sid": "1734"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/authorized-key/name",
+        "identifier": "/ietf-system:system/authentication",
         "sid": "1735"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/name",
+        "identifier": "/ietf-system:system/authentication/user",
         "sid": "1736"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/password",
+        "identifier": "/ietf-system:system/authentication/user-\
+                                               authentication-order",
         "sid": "1737"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock",
+        "identifier": "/ietf-system:system/authentication/user/\
+                                                     authorized-key",
         "sid": "1738"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone-name",
+        "identifier": "/ietf-system:system/authentication/user/\
+                                           authorized-key/algorithm",
         "sid": "1739"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone-utc-offset",
+        "identifier": "/ietf-system:system/authentication/user/\
+                                            authorized-key/key-data",
         "sid": "1740"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/contact",
+        "identifier": "/ietf-system:system/authentication/user/\
+                                                authorized-key/name",
         "sid": "1741"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver",
+        "identifier": "/ietf-system:system/authentication/user/name",
         "sid": "1742"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options",
+        "identifier": "/ietf-system:system/authentication/user/\
+                                                           password",
         "sid": "1743"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options/attempts",
+        "identifier": "/ietf-system:system/clock",
         "sid": "1744"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options/timeout",
+        "identifier": "/ietf-system:system/clock/timezone",
         "sid": "1745"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/search",
+        "identifier": "/ietf-system:system/clock/timezone/timezone-\
+                                                               name",
         "sid": "1746"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server",
+        "identifier": "/ietf-system:system/clock/timezone/timezone-\
+                                                 name/timezone-name",
         "sid": "1747"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/name",
+        "identifier": "/ietf-system:system/clock/timezone/timezone-\
+                                                         utc-offset",
         "sid": "1748"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp",
+        "identifier": "/ietf-system:system/clock/timezone/timezone-\
+                                     utc-offset/timezone-utc-offset",
         "sid": "1749"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp/address",
+        "identifier": "/ietf-system:system/contact",
         "sid": "1750"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp/port",
+        "identifier": "/ietf-system:system/dns-resolver",
         "sid": "1751"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/hostname",
+        "identifier": "/ietf-system:system/dns-resolver/options",
         "sid": "1752"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/location",
+        "identifier": "/ietf-system:system/dns-resolver/options/\
+                                                           attempts",
         "sid": "1753"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp",
+        "identifier": "/ietf-system:system/dns-resolver/options/\
+                                                            timeout",
         "sid": "1754"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/enabled",
+        "identifier": "/ietf-system:system/dns-resolver/search",
         "sid": "1755"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server",
+        "identifier": "/ietf-system:system/dns-resolver/server",
         "sid": "1756"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/association-type",
+        "identifier": "/ietf-system:system/dns-resolver/server/name",
         "sid": "1757"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/iburst",
+        "identifier": "/ietf-system:system/dns-resolver/server/\
+                                                          transport",
         "sid": "1758"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/name",
+        "identifier": "/ietf-system:system/dns-resolver/server/\
+                                              transport/udp-and-tcp",
         "sid": "1759"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/prefer",
+        "identifier": "/ietf-system:system/dns-resolver/server/\
+                                  transport/udp-and-tcp/udp-and-tcp",
         "sid": "1760"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/udp",
+        "identifier": "/ietf-system:system/dns-resolver/server/\
+                          transport/udp-and-tcp/udp-and-tcp/address",
         "sid": "1761"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/udp/address",
+        "identifier": "/ietf-system:system/dns-resolver/server/\
+                             transport/udp-and-tcp/udp-and-tcp/port",
         "sid": "1762"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/udp/port",
+        "identifier": "/ietf-system:system/hostname",
         "sid": "1763"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius",
+        "identifier": "/ietf-system:system/location",
         "sid": "1764"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/options",
+        "identifier": "/ietf-system:system/ntp",
         "sid": "1765"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/options/attempts",
+        "identifier": "/ietf-system:system/ntp/enabled",
         "sid": "1766"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/options/timeout",
+        "identifier": "/ietf-system:system/ntp/server",
         "sid": "1767"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server",
+        "identifier": "/ietf-system:system/ntp/server/association-\
+                                                               type",
         "sid": "1768"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/authentication-type",
+        "identifier": "/ietf-system:system/ntp/server/iburst",
         "sid": "1769"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/name",
+        "identifier": "/ietf-system:system/ntp/server/name",
         "sid": "1770"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/udp",
+        "identifier": "/ietf-system:system/ntp/server/prefer",
         "sid": "1771"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/udp/address",
+        "identifier": "/ietf-system:system/ntp/server/transport",
         "sid": "1772"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/udp/authentication-port",
+        "identifier": "/ietf-system:system/ntp/server/transport/udp",
         "sid": "1773"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/udp/shared-secret",
+        "identifier": "/ietf-system:system/ntp/server/transport/udp/\
+                                                                udp",
         "sid": "1774"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/transport/udp/\
+                                                        udp/address",
+        "sid": "1775"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/transport/udp/\
+                                                           udp/port",
+        "sid": "1776"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius",
+        "sid": "1777"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/options",
+        "sid": "1778"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/options/attempts",
+        "sid": "1779"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/options/timeout",
+        "sid": "1780"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server",
+        "sid": "1781"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/\
+                                                authentication-type",
+        "sid": "1782"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/name",
+        "sid": "1783"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/transport",
+        "sid": "1784"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/transport/\
+                                                                udp",
+        "sid": "1785"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/transport/\
+                                                            udp/udp",
+        "sid": "1786"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/transport/\
+                                                    udp/udp/address",
+        "sid": "1787"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/transport/\
+                                        udp/udp/authentication-port",
+        "sid": "1788"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/radius/server/transport/\
+                                              udp/udp/shared-secret",
+        "sid": "1789"
       }
     ]
   }

--- a/code/ietf-system.sid
+++ b/code/ietf-system.sid
@@ -111,404 +111,302 @@
       {
         "namespace": "data",
         "identifier": "/ietf-system:set-current-datetime/input",
-        "sid": "1716"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:set-current-datetime/input/\
-                                                   current-datetime",
-        "sid": "1717"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:set-current-datetime/output",
-        "sid": "1718"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system",
-        "sid": "1719"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-restart",
-        "sid": "1720"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-restart/input",
-        "sid": "1721"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-restart/output",
-        "sid": "1722"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-shutdown",
-        "sid": "1723"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-shutdown/input",
-        "sid": "1724"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-shutdown/output",
-        "sid": "1725"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state",
-        "sid": "1726"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/clock",
-        "sid": "1727"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/clock/boot-datetime\
-                                                                   ",
-        "sid": "1728"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/clock/current-\
-                                                           datetime",
-        "sid": "1729"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform",
-        "sid": "1730"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/machine",
-        "sid": "1731"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/os-name",
-        "sid": "1732"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/os-release\
-                                                                   ",
-        "sid": "1733"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system-state/platform/os-version\
-                                                                   ",
-        "sid": "1734"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication",
-        "sid": "1735"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user",
-        "sid": "1736"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user-\
-                                               authentication-order",
-        "sid": "1737"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/\
-                                                     authorized-key",
-        "sid": "1738"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/\
-                                           authorized-key/algorithm",
-        "sid": "1739"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/\
-                                            authorized-key/key-data",
-        "sid": "1740"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/\
-                                                authorized-key/name",
-        "sid": "1741"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/name",
-        "sid": "1742"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/authentication/user/\
-                                                           password",
-        "sid": "1743"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/clock",
-        "sid": "1744"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone",
-        "sid": "1745"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-\
-                                                               name",
-        "sid": "1746"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-\
-                                                 name/timezone-name",
-        "sid": "1747"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-\
-                                                         utc-offset",
-        "sid": "1748"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/clock/timezone/timezone-\
-                                     utc-offset/timezone-utc-offset",
-        "sid": "1749"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/contact",
-        "sid": "1750"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver",
-        "sid": "1751"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options",
-        "sid": "1752"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options/\
-                                                           attempts",
-        "sid": "1753"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/options/\
-                                                            timeout",
-        "sid": "1754"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/search",
-        "sid": "1755"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server",
-        "sid": "1756"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/name",
-        "sid": "1757"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/\
-                                                          transport",
-        "sid": "1758"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/\
-                                              transport/udp-and-tcp",
-        "sid": "1759"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/\
-                                  transport/udp-and-tcp/udp-and-tcp",
-        "sid": "1760"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/\
-                          transport/udp-and-tcp/udp-and-tcp/address",
-        "sid": "1761"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/dns-resolver/server/\
-                             transport/udp-and-tcp/udp-and-tcp/port",
-        "sid": "1762"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/hostname",
-        "sid": "1763"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/location",
-        "sid": "1764"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp",
-        "sid": "1765"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/enabled",
-        "sid": "1766"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server",
-        "sid": "1767"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/association-\
-                                                               type",
-        "sid": "1768"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/iburst",
-        "sid": "1769"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/name",
-        "sid": "1770"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/prefer",
-        "sid": "1771"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport",
-        "sid": "1772"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp",
-        "sid": "1773"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp/\
-                                                                udp",
-        "sid": "1774"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp/\
-                                                        udp/address",
         "sid": "1775"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/ntp/server/transport/udp/\
-                                                           udp/port",
+        "identifier": "/ietf-system:set-current-datetime/input/current-datetime",
         "sid": "1776"
       },
       {
         "namespace": "data",
+        "identifier": "/ietf-system:system",
+        "sid": "1717"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-restart",
+        "sid": "1718"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-shutdown",
+        "sid": "1719"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state",
+        "sid": "1720"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/clock",
+        "sid": "1721"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/clock/boot-datetime",
+        "sid": "1722"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/clock/current-datetime",
+        "sid": "1723"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/platform",
+        "sid": "1724"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/platform/machine",
+        "sid": "1725"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/platform/os-name",
+        "sid": "1726"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/platform/os-release",
+        "sid": "1727"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-state/platform/os-version",
+        "sid": "1728"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication",
+        "sid": "1729"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user",
+        "sid": "1730"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user-authentication-order",
+        "sid": "1731"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user/authorized-key",
+        "sid": "1732"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user/authorized-key/algorithm",
+        "sid": "1733"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user/authorized-key/key-data",
+        "sid": "1734"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user/authorized-key/name",
+        "sid": "1735"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user/name",
+        "sid": "1736"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/authentication/user/password",
+        "sid": "1737"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/clock",
+        "sid": "1738"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/clock/timezone-name",
+        "sid": "1739"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/clock/timezone-utc-offset",
+        "sid": "1740"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/contact",
+        "sid": "1741"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver",
+        "sid": "1742"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/options",
+        "sid": "1743"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/options/attempts",
+        "sid": "1744"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/options/timeout",
+        "sid": "1745"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/search",
+        "sid": "1746"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/server",
+        "sid": "1747"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/server/name",
+        "sid": "1748"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp",
+        "sid": "1749"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp/address",
+        "sid": "1750"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/dns-resolver/server/udp-and-tcp/port",
+        "sid": "1751"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/hostname",
+        "sid": "1752"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/location",
+        "sid": "1753"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp",
+        "sid": "1754"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/enabled",
+        "sid": "1755"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server",
+        "sid": "1756"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/association-type",
+        "sid": "1757"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/iburst",
+        "sid": "1758"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/name",
+        "sid": "1759"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/prefer",
+        "sid": "1760"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/udp",
+        "sid": "1761"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/udp/address",
+        "sid": "1762"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system/ntp/server/udp/port",
+        "sid": "1763"
+      },
+      {
+        "namespace": "data",
         "identifier": "/ietf-system:system/radius",
-        "sid": "1777"
+        "sid": "1764"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/options",
-        "sid": "1778"
+        "sid": "1765"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/options/attempts",
-        "sid": "1779"
+        "sid": "1766"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/options/timeout",
-        "sid": "1780"
+        "sid": "1767"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/server",
-        "sid": "1781"
+        "sid": "1768"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/\
-                                                authentication-type",
-        "sid": "1782"
+        "identifier": "/ietf-system:system/radius/server/authentication-type",
+        "sid": "1769"
       },
       {
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/server/name",
-        "sid": "1783"
+        "sid": "1770"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport",
-        "sid": "1784"
+        "identifier": "/ietf-system:system/radius/server/udp",
+        "sid": "1771"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/\
-                                                                udp",
-        "sid": "1785"
+        "identifier": "/ietf-system:system/radius/server/udp/address",
+        "sid": "1772"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/\
-                                                            udp/udp",
-        "sid": "1786"
+        "identifier": "/ietf-system:system/radius/server/udp/authentication-port",
+        "sid": "1773"
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/\
-                                                    udp/udp/address",
-        "sid": "1787"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/\
-                                        udp/udp/authentication-port",
-        "sid": "1788"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:system/radius/server/transport/\
-                                              udp/udp/shared-secret",
-        "sid": "1789"
+        "identifier": "/ietf-system:system/radius/server/udp/shared-secret",
+        "sid": "1774"
       }
     ]
   }

--- a/code/ietf-system.sid
+++ b/code/ietf-system.sid
@@ -2,11 +2,13 @@
   "ietf-sid-file:sid-file": {
     "module-name": "ietf-system",
     "module-revision": "2014-08-06",
+    "sid-file-version": 1,
+    "sid-file-status": "unpublished",
     "description": "Example sid file",
     "dependency-revision": [
       {
-        "module-name": "ietf-yang-types",
-        "module-revision": "2013-07-15"
+        "module-name": "iana-crypt-hash",
+        "module-revision": "2014-08-06"
       },
       {
         "module-name": "ietf-inet-types",
@@ -17,8 +19,8 @@
         "module-revision": "2018-02-14"
       },
       {
-        "module-name": "iana-crypt-hash",
-        "module-revision": "2014-08-06"
+        "module-name": "ietf-yang-types",
+        "module-revision": "2013-07-15"
       }
     ],
     "assignment-range": [
@@ -110,13 +112,9 @@
       },
       {
         "namespace": "data",
-        "identifier": "/ietf-system:set-current-datetime/input",
-        "sid": "1775"
-      },
-      {
-        "namespace": "data",
-        "identifier": "/ietf-system:set-current-datetime/input/current-datetime",
-        "sid": "1776"
+        "identifier": "/ietf-system:set-current-datetime/output",
+        "status": "unstable",
+        "sid": "1716"
       },
       {
         "namespace": "data",
@@ -407,6 +405,40 @@
         "namespace": "data",
         "identifier": "/ietf-system:system/radius/server/udp/shared-secret",
         "sid": "1774"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:set-current-datetime/input",
+        "sid": "1775"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:set-current-datetime/input/current-datetime",
+        "sid": "1776"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-restart/input",
+        "status": "unstable",
+        "sid": "1777"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-restart/output",
+        "status": "unstable",
+        "sid": "1778"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-shutdown/input",
+        "status": "unstable",
+        "sid": "1779"
+      },
+      {
+        "namespace": "data",
+        "identifier": "/ietf-system:system-shutdown/output",
+        "status": "unstable",
+        "sid": "1780"
       }
     ]
   }

--- a/code/ietf-system.yang
+++ b/code/ietf-system.yang
@@ -1,0 +1,800 @@
+module ietf-system {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-system";
+  prefix "sys";
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import ietf-netconf-acm {
+    prefix nacm;
+  }
+
+  import iana-crypt-hash {
+    prefix ianach;
+  }
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Thomas Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Juergen Schoenwaelder
+               <mailto:j.schoenwaelder@jacobs-university.de>
+
+     Editor:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+  description
+    "This module contains a collection of YANG definitions for the
+     configuration and identification of some common system
+     properties within a device containing a NETCONF server.  This
+     includes data node definitions for system identification,
+     time-of-day management, user management, DNS resolver
+     configuration, and some protocol operations for system
+     management.
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7317; see
+     the RFC itself for full legal notices.";
+
+  revision 2014-08-06 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7317: A YANG Data Model for System Management";
+  }
+
+ /*
+  * Typedefs
+  */
+
+  typedef timezone-name {
+    type string;
+    description
+      "A time zone name as used by the Time Zone Database,
+       sometimes referred to as the 'Olson Database'.
+
+       The exact set of valid values is an implementation-specific
+       matter.  Client discovery of the exact set of time zone names
+       for a particular server is out of scope.";
+    reference
+      "RFC 6557: Procedures for Maintaining the Time Zone Database";
+   }
+
+  /*
+   * Features
+   */
+
+  feature radius {
+    description
+      "Indicates that the device can be configured as a RADIUS
+       client.";
+    reference
+      "RFC 2865: Remote Authentication Dial In User Service (RADIUS)";
+  }
+
+  feature authentication {
+    description
+      "Indicates that the device supports configuration of
+       user authentication.";
+  }
+
+  feature local-users {
+    if-feature authentication;
+    description
+      "Indicates that the device supports configuration of
+       local user authentication.";
+  }
+
+  feature radius-authentication {
+    if-feature radius;
+    if-feature authentication;
+    description
+      "Indicates that the device supports configuration of user
+       authentication over RADIUS.";
+    reference
+      "RFC 2865: Remote Authentication Dial In User Service (RADIUS)
+       RFC 5607: Remote Authentication Dial-In User Service (RADIUS)
+                 Authorization for Network Access Server (NAS)
+                 Management";
+  }
+
+  feature ntp {
+    description
+      "Indicates that the device can be configured to use one or
+       more NTP servers to set the system date and time.";
+  }
+
+  feature ntp-udp-port {
+    if-feature ntp;
+    description
+      "Indicates that the device supports the configuration of
+       the UDP port for NTP servers.
+
+       This is a 'feature', since many implementations do not support
+       any port other than the default port.";
+  }
+
+  feature timezone-name {
+    description
+      "Indicates that the local time zone on the device
+       can be configured to use the TZ database
+       to set the time zone and manage daylight saving time.";
+    reference
+      "RFC 6557: Procedures for Maintaining the Time Zone Database";
+  }
+
+  feature dns-udp-tcp-port {
+    description
+      "Indicates that the device supports the configuration of
+       the UDP and TCP port for DNS servers.
+
+       This is a 'feature', since many implementations do not support
+       any port other than the default port.";
+  }
+
+  /*
+   * Identities
+   */
+
+  identity authentication-method {
+    description
+      "Base identity for user authentication methods.";
+  }
+
+  identity radius {
+    base authentication-method;
+    description
+      "Indicates user authentication using RADIUS.";
+    reference
+      "RFC 2865: Remote Authentication Dial In User Service (RADIUS)
+       RFC 5607: Remote Authentication Dial-In User Service (RADIUS)
+                 Authorization for Network Access Server (NAS)
+                 Management";
+  }
+
+  identity local-users {
+    base authentication-method;
+    description
+      "Indicates password-based authentication of locally
+       configured users.";
+  }
+
+  identity radius-authentication-type {
+    description
+      "Base identity for RADIUS authentication types.";
+  }
+
+  identity radius-pap {
+    base radius-authentication-type;
+    description
+      "The device requests Password Authentication Protocol (PAP)
+       authentication from the RADIUS server.";
+    reference
+      "RFC 2865: Remote Authentication Dial In User Service (RADIUS)";
+  }
+
+  identity radius-chap {
+    base radius-authentication-type;
+    description
+      "The device requests Challenge Handshake Authentication
+       Protocol (CHAP) authentication from the RADIUS server.";
+    reference
+      "RFC 2865: Remote Authentication Dial In User Service (RADIUS)";
+  }
+
+  /*
+   * Configuration data nodes
+   */
+
+  container system {
+    description
+      "System group configuration.";
+
+    leaf contact {
+      type string;
+      description
+        "The administrator contact information for the system.
+
+         A server implementation MAY map this leaf to the sysContact
+         MIB object.  Such an implementation needs to use some
+         mechanism to handle the differences in size and characters
+         allowed between this leaf and sysContact.  The definition of
+         such a mechanism is outside the scope of this document.";
+      reference
+        "RFC 3418: Management Information Base (MIB) for the
+                   Simple Network Management Protocol (SNMP)
+                   SNMPv2-MIB.sysContact";
+    }
+    leaf hostname {
+      type inet:domain-name;
+     description
+       "The name of the host.  This name can be a single domain
+        label or the fully qualified domain name of the host.";
+    }
+    leaf location {
+      type string;
+      description
+        "The system location.
+
+         A server implementation MAY map this leaf to the sysLocation
+         MIB object.  Such an implementation needs to use some
+         mechanism to handle the differences in size and characters
+         allowed between this leaf and sysLocation.  The definition
+         of such a mechanism is outside the scope of this document.";
+      reference
+        "RFC 3418: Management Information Base (MIB) for the
+                   Simple Network Management Protocol (SNMP)
+                   SNMPv2-MIB.sysLocation";
+    }
+
+    container clock {
+      description
+        "Configuration of the system date and time properties.";
+
+      choice timezone {
+        description
+          "The system time zone information.";
+
+        case timezone-name {
+          if-feature timezone-name;
+          leaf timezone-name {
+            type timezone-name;
+            description
+              "The TZ database name to use for the system, such
+               as 'Europe/Stockholm'.";
+          }
+        }
+        case timezone-utc-offset {
+          leaf timezone-utc-offset {
+            type int16 {
+              range "-1500 .. 1500";
+            }
+            units "minutes";
+            description
+              "The number of minutes to add to UTC time to
+               identify the time zone for this system.  For example,
+               'UTC - 8:00 hours' would be represented as '-480'.
+               Note that automatic daylight saving time adjustment
+               is not provided if this object is used.";
+          }
+        }
+      }
+    }
+
+    container ntp {
+      if-feature ntp;
+      presence
+        "Enables the NTP client unless the 'enabled' leaf
+         (which defaults to 'true') is set to 'false'";
+      description
+        "Configuration of the NTP client.";
+
+      leaf enabled {
+        type boolean;
+        default true;
+        description
+          "Indicates that the system should attempt to
+           synchronize the system clock with an NTP server
+           from the 'ntp/server' list.";
+      }
+      list server {
+        key name;
+        description
+          "List of NTP servers to use for system clock
+           synchronization.  If '/system/ntp/enabled'
+           is 'true', then the system will attempt to
+           contact and utilize the specified NTP servers.";
+
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for the NTP server.";
+        }
+        choice transport {
+          mandatory true;
+          description
+            "The transport-protocol-specific parameters for this
+             server.";
+
+          case udp {
+            container udp {
+              description
+                "Contains UDP-specific configuration parameters
+                 for NTP.";
+              leaf address {
+                type inet:host;
+                mandatory true;
+                description
+                  "The address of the NTP server.";
+              }
+              leaf port {
+                if-feature ntp-udp-port;
+                type inet:port-number;
+                default 123;
+                description
+                  "The port number of the NTP server.";
+              }
+            }
+          }
+        }
+        leaf association-type {
+          type enumeration {
+            enum server {
+              description
+                "Use client association mode.  This device
+                 will not provide synchronization to the
+                 configured NTP server.";
+            }
+            enum peer {
+              description
+                "Use symmetric active association mode.
+                 This device may provide synchronization
+                 to the configured NTP server.";
+            }
+            enum pool {
+              description
+                "Use client association mode with one or
+                 more of the NTP servers found by DNS
+                 resolution of the domain name given by
+                 the 'address' leaf.  This device will not
+                 provide synchronization to the servers.";
+            }
+          }
+          default server;
+          description
+            "The desired association type for this NTP server.";
+        }
+        leaf iburst {
+          type boolean;
+          default false;
+          description
+            "Indicates whether this server should enable burst
+             synchronization or not.";
+        }
+        leaf prefer {
+          type boolean;
+          default false;
+          description
+            "Indicates whether this server should be preferred
+             or not.";
+        }
+      }
+    }
+
+    container dns-resolver {
+      description
+        "Configuration of the DNS resolver.";
+
+      leaf-list search {
+        type inet:domain-name;
+        ordered-by user;
+        description
+          "An ordered list of domains to search when resolving
+           a host name.";
+      }
+      list server {
+        key name;
+        ordered-by user;
+        description
+          "List of the DNS servers that the resolver should query.
+
+           When the resolver is invoked by a calling application, it
+           sends the query to the first name server in this list.  If
+           no response has been received within 'timeout' seconds,
+           the resolver continues with the next server in the list.
+           If no response is received from any server, the resolver
+           continues with the first server again.  When the resolver
+           has traversed the list 'attempts' times without receiving
+           any response, it gives up and returns an error to the
+           calling application.
+
+           Implementations MAY limit the number of entries in this
+           list.";
+
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for the DNS server.";
+        }
+        choice transport {
+          mandatory true;
+          description
+            "The transport-protocol-specific parameters for this
+             server.";
+
+          case udp-and-tcp {
+            container udp-and-tcp {
+              description
+                "Contains UDP- and TCP-specific configuration
+                 parameters for DNS.";
+              reference
+                "RFC 1035: Domain Names - Implementation and
+                           Specification
+                 RFC 5966: DNS Transport over TCP - Implementation
+                           Requirements";
+
+              leaf address {
+                type inet:ip-address;
+                mandatory true;
+                description
+                  "The address of the DNS server.";
+              }
+              leaf port {
+                if-feature dns-udp-tcp-port;
+                type inet:port-number;
+                default 53;
+                description
+                  "The UDP and TCP port number of the DNS server.";
+              }
+            }
+          }
+        }
+      }
+      container options {
+        description
+          "Resolver options.  The set of available options has been
+           limited to those that are generally available across
+           different resolver implementations and generally useful.";
+        leaf timeout {
+          type uint8 {
+            range "1..max";
+          }
+          units "seconds";
+          default "5";
+          description
+            "The amount of time the resolver will wait for a
+             response from each remote name server before
+             retrying the query via a different name server.";
+        }
+        leaf attempts {
+          type uint8 {
+            range "1..max";
+          }
+          default "2";
+          description
+            "The number of times the resolver will send a query to
+             all of its name servers before giving up and returning
+             an error to the calling application.";
+        }
+      }
+    }
+
+    container radius {
+      if-feature radius;
+
+      description
+        "Configuration of the RADIUS client.";
+
+      list server {
+        key name;
+        ordered-by user;
+        description
+          "List of RADIUS servers used by the device.
+
+           When the RADIUS client is invoked by a calling
+           application, it sends the query to the first server in
+           this list.  If no response has been received within
+           'timeout' seconds, the client continues with the next
+           server in the list.  If no response is received from any
+           server, the client continues with the first server again.
+           When the client has traversed the list 'attempts' times
+           without receiving any response, it gives up and returns an
+           error to the calling application.";
+
+        leaf name {
+          type string;
+          description
+            "An arbitrary name for the RADIUS server.";
+        }
+        choice transport {
+          mandatory true;
+          description
+            "The transport-protocol-specific parameters for this
+             server.";
+
+          case udp {
+            container udp {
+              description
+                "Contains UDP-specific configuration parameters
+                 for RADIUS.";
+              leaf address {
+                type inet:host;
+                mandatory true;
+                description
+                  "The address of the RADIUS server.";
+              }
+
+              leaf authentication-port {
+                type inet:port-number;
+                default "1812";
+                description
+                  "The port number of the RADIUS server.";
+              }
+              leaf shared-secret {
+                type string;
+                mandatory true;
+                nacm:default-deny-all;
+                description
+                  "The shared secret, which is known to both the
+                   RADIUS client and server.";
+                reference
+                  "RFC 2865: Remote Authentication Dial In User
+                             Service (RADIUS)";
+              }
+            }
+          }
+        }
+        leaf authentication-type {
+          type identityref {
+            base radius-authentication-type;
+          }
+          default radius-pap;
+          description
+            "The authentication type requested from the RADIUS
+             server.";
+        }
+      }
+      container options {
+        description
+          "RADIUS client options.";
+
+        leaf timeout {
+          type uint8 {
+            range "1..max";
+          }
+          units "seconds";
+          default "5";
+          description
+            "The number of seconds the device will wait for a
+             response from each RADIUS server before trying with a
+             different server.";
+        }
+
+        leaf attempts {
+          type uint8 {
+            range "1..max";
+          }
+          default "2";
+          description
+            "The number of times the device will send a query to
+             all of its RADIUS servers before giving up.";
+        }
+      }
+    }
+
+    container authentication {
+      nacm:default-deny-write;
+      if-feature authentication;
+
+       description
+         "The authentication configuration subtree.";
+
+       leaf-list user-authentication-order {
+         type identityref {
+           base authentication-method;
+         }
+         must '(. != "sys:radius" or ../../radius/server)' {
+           error-message
+             "When 'radius' is used, a RADIUS server"
+           + " must be configured.";
+           description
+             "When 'radius' is used as an authentication method,
+              a RADIUS server must be configured.";
+         }
+         ordered-by user;
+
+         description
+           "When the device authenticates a user with a password,
+            it tries the authentication methods in this leaf-list in
+            order.  If authentication with one method fails, the next
+            method is used.  If no method succeeds, the user is
+            denied access.
+
+            An empty user-authentication-order leaf-list still allows
+            authentication of users using mechanisms that do not
+            involve a password.
+
+            If the 'radius-authentication' feature is advertised by
+            the NETCONF server, the 'radius' identity can be added to
+            this list.
+
+            If the 'local-users' feature is advertised by the
+            NETCONF server, the 'local-users' identity can be
+            added to this list.";
+       }
+
+       list user {
+         if-feature local-users;
+         key name;
+         description
+           "The list of local users configured on this device.";
+
+         leaf name {
+           type string;
+           description
+            "The user name string identifying this entry.";
+         }
+         leaf password {
+           type ianach:crypt-hash;
+           description
+             "The password for this entry.";
+         }
+         list authorized-key {
+           key name;
+           description
+             "A list of public SSH keys for this user.  These keys
+              are allowed for SSH authentication, as described in
+              RFC 4253.";
+           reference
+             "RFC 4253: The Secure Shell (SSH) Transport Layer
+                        Protocol";
+
+           leaf name {
+             type string;
+             description
+               "An arbitrary name for the SSH key.";
+           }
+
+           leaf algorithm {
+             type string;
+             mandatory true;
+             description
+               "The public key algorithm name for this SSH key.
+
+                Valid values are the values in the IANA 'Secure Shell
+                (SSH) Protocol Parameters' registry, Public Key
+                Algorithm Names.";
+             reference
+               "IANA 'Secure Shell (SSH) Protocol Parameters'
+                registry, Public Key Algorithm Names";
+           }
+           leaf key-data {
+             type binary;
+             mandatory true;
+             description
+               "The binary public key data for this SSH key, as
+                specified by RFC 4253, Section 6.6, i.e.:
+
+                  string    certificate or public key format
+                            identifier
+                  byte[n]   key/certificate data.";
+             reference
+               "RFC 4253: The Secure Shell (SSH) Transport Layer
+                          Protocol";
+           }
+         }
+       }
+     }
+  }
+
+  /*
+   * Operational state data nodes
+   */
+
+  container system-state {
+    config false;
+    description
+      "System group operational state.";
+
+    container platform {
+      description
+        "Contains vendor-specific information for
+         identifying the system platform and operating system.";
+      reference
+        "IEEE Std 1003.1-2008 - sys/utsname.h";
+
+      leaf os-name {
+        type string;
+        description
+          "The name of the operating system in use -
+           for example, 'Linux'.";
+        reference
+          "IEEE Std 1003.1-2008 - utsname.sysname";
+      }
+      leaf os-release {
+        type string;
+        description
+          "The current release level of the operating
+           system in use.  This string MAY indicate
+           the OS source code revision.";
+        reference
+          "IEEE Std 1003.1-2008 - utsname.release";
+      }
+      leaf os-version {
+        type string;
+        description
+          "The current version level of the operating
+           system in use.  This string MAY indicate
+           the specific OS build date and target variant
+           information.";
+        reference
+          "IEEE Std 1003.1-2008 - utsname.version";
+      }
+      leaf machine {
+        type string;
+        description
+          "A vendor-specific identifier string representing
+           the hardware in use.";
+        reference
+          "IEEE Std 1003.1-2008 - utsname.machine";
+      }
+    }
+
+    container clock {
+      description
+        "Monitoring of the system date and time properties.";
+
+      leaf current-datetime {
+        type yang:date-and-time;
+        description
+          "The current system date and time.";
+      }
+
+      leaf boot-datetime {
+        type yang:date-and-time;
+        description
+          "The system date and time when the system last restarted.";
+      }
+    }
+  }
+
+  rpc set-current-datetime {
+    nacm:default-deny-all;
+    description
+      "Set the /system-state/clock/current-datetime leaf
+       to the specified value.
+
+       If the system is using NTP (i.e., /system/ntp/enabled
+       is set to 'true'), then this operation will fail with
+       error-tag 'operation-failed' and error-app-tag value of
+       'ntp-active'.";
+    input {
+      leaf current-datetime {
+        type yang:date-and-time;
+        mandatory true;
+        description
+          "The current system date and time.";
+      }
+    }
+  }
+
+  rpc system-restart {
+    nacm:default-deny-all;
+    description
+      "Request that the entire system be restarted immediately.
+       A server SHOULD send an rpc reply to the client before
+       restarting the system.";
+  }
+
+  rpc system-shutdown {
+    nacm:default-deny-all;
+    description
+      "Request that the entire system be shut down immediately.
+       A server SHOULD send an rpc reply to the client before
+       shutting down the system.";
+  }
+
+}

--- a/draft-ietf-core-sid.md
+++ b/draft-ietf-core-sid.md
@@ -38,8 +38,8 @@ author:
 - role: editor
   ins: A. Pelov
   name: Alexander Pelov
-  org: IMT Atlantique 
-  street: 2 rue de la Châtaigneraie 
+  org: IMT Atlantique
+  street: 2 rue de la Châtaigneraie
   code: '35510'
   city: Cesson-Sevigne
   region: Bretagne


### PR DESCRIPTION
The now [RFC9595](https://datatracker.ietf.org/doc/rfc9595/) contains Example '.sid' File in appendix.

Fix the example to follow rules defined in the normative body of the RFC.


There already exists errata [EID 8629](https://www.rfc-editor.org/errata/eid8629) which is wrong with the new WG consensus for wording of the RFC9595.


TODO: should the file have `"sid-file-status": "unpublished"`?
TODO: should the new 'item' list entries have `"status": "unstable"`?
TODO: should the file have updated revision i.e. `"sid-file-version": 1`?