### PR TITLE
draft-core-yang-library: SID File version for implemented module

### DIFF
--- a/draft-ietf-core-yang-library-latest.md
+++ b/draft-ietf-core-yang-library-latest.md
@@ -383,6 +383,13 @@ module ietf-constrained-yang-library {
       }
 
       uses implementation-parameters;
+
+      leaf sid-file-version {
+        type sid:sid-file-version-identifier; 
+        description
+          "Version of the '.sid' file in active use by the server
+           for given module."
+      }
     }
     list import-only-module {
       key "identifier revision";


### PR DESCRIPTION
SID File have it's own versioning independent on the YANG revisions. It may be useful to have the version stored in the constrained YANG Library.