### PR TITLE
draft-core-yang-library: Use empty type for revisionless modules

### DIFF
--- a/draft-ietf-core-yang-library-latest.md
+++ b/draft-ietf-core-yang-library-latest.md
@@ -405,12 +405,11 @@ module ietf-constrained-yang-library {
       leaf revision {
         type union {
           type revision-identifier;
-          type string {
-            length 0;
-          }
+          type empty;
         }
         description
-          "The YANG module revision date.";
+          "The YANG module revision date. If the type is empty,
+           module with no revision statement is being identified";
       }
       leaf namespace {
         type inet:uri;


### PR DESCRIPTION
It is common for the YANG modules of NETMOD and NETCONF WGs to have a lot of string-based types leafs. This may be cause by the fact that XML and JSON does not have very rich data model, and/or by the fact that YANG 1 does not support empty type as a list key.

From the YANG 1.1, it is possible to use empty type for list key leafs. Therefore we utilize this for modules without revision statement to identify such modules in the module sets. We found this type better suited than the prevision string { length 0; } type.

The empty type is encoded as CBOR `null` which uses 1 byte, same length as empty text string (`""`).