### PR TITLE
draft-core-yang-library: Unconstrained YANG Library reference

### DIFF
--- a/draft-ietf-core-yang-library-latest.md
+++ b/draft-ietf-core-yang-library-latest.md
@@ -533,6 +533,16 @@ module ietf-constrained-yang-library {
          the 'yang-library' tree, except 'yang-library/checksum',
          has changed.";
     }
+
+    leaf unconstrained-library {
+      type inet:uri;
+      description
+        "To minimalize the need of populating the 'location' URI
+         list referencing YANG module and submodule resources,
+         the implementation can instantiate just this leaf with the 
+         resource URI to the YANG Library as defined in RFC8525";
+      reference "RFC8525: YANG Library";
+    }
   }
 
   /*


### PR DESCRIPTION
Add one new leaf referencing RFC8525 YANG Library resource.

If the constrained node does not implement any `'location'` list for each one module (as recommended by the text), we want to allow the node to have one string referencing the 'unconstrained' YANG Library. This way, human discovery of supported nodes improve greatly for little to no penalty.