### PR TITLE
Require instance for leafrefs

### DIFF
--- a/draft-ietf-core-yang-library-latest.md
+++ b/draft-ietf-core-yang-library-latest.md
@@ -325,6 +325,7 @@ module ietf-constrained-yang-library {
     leaf-list deviation {
       type leafref {
         path "../../module/identifier";
+        require-instance true;
       }
       description
         "List of all YANG deviation modules used by this server to
@@ -471,6 +472,7 @@ module ietf-constrained-yang-library {
       leaf-list module-set {
         type leafref {
           path "../../module-set/index";
+          require-instance true;
         }
         description
           "A set of module-sets that are included in this schema.
@@ -501,6 +503,7 @@ module ietf-constrained-yang-library {
       leaf schema {
         type leafref {
           path "../../schema/index";
+          require-instance true;
         }
         mandatory true;
         description


### PR DESCRIPTION
The `leafref`s by default are not required to point to existing instance. This change makes it harder for the constrained devices to implemented the Constrained YANG Library. This reason could lead to rejection of this change.

Make the `leafref` direct references from datastore list to schema list, and from schema list to module set list always valid. Valid in a sense that the reference target exists.