### PR TITLE
editorial: Be more explicit about NIDs

### DIFF
--- a/code/ietf-sid-file.yang
+++ b/code/ietf-sid-file.yang
@@ -90,16 +90,17 @@ module ietf-sid-file {
       "[RFC XXXX] YANG Schema Item iDentifier (YANG SID)";
   }
 
-  typedef schema-node-path {
+  typedef node-item-identifier {
     type string {
       pattern
         '/[a-zA-Z_][a-zA-Z0-9\-_.]*:[a-zA-Z_][a-zA-Z0-9\-_.]*' +
         '(/[a-zA-Z_][a-zA-Z0-9\-_.]*(:[a-zA-Z_][a-zA-Z0-9\-_.]*)?)*';
     }
     description
-      "A schema-node path is an absolute YANG schema node identifier
+      "A node-item-identifier path is an absolute YANG schema node identifier
       as defined by the YANG ABNF rule absolute-schema-nodeid,
-      except that module names are used instead of prefixes.
+      except that module names are used instead of prefixes and
+      choice and case schema nodes are omitted.
 
       This string additionally follows the following rules:
 
@@ -324,7 +325,7 @@ module ietf-sid-file {
       leaf identifier {
         type union {
           type yang:yang-identifier;
-          type schema-node-path;
+          type node-item-identifier;
         }
         description
           "String identifier of the YANG item for this mapping

--- a/draft-ietf-core-sid.md
+++ b/draft-ietf-core-sid.md
@@ -210,6 +210,10 @@ This specification also makes use of the following terminology:
 * YANG Name: Text string used to identify different YANG items
   (cf. {{Section 3.3 of RFC9254}}).
 
+* YANG Node Item iDentifier (YANG NID or simply NID): Text string
+  used to identify different YANG items. Some NIDs are identified by YANG Name,
+  namely module, submodule, identity and feature items.
+
 # Objectives
 
 The overriding objective of the SID assignment and registration system is to
@@ -490,7 +494,8 @@ For an example of this update process, see activity diagram
 # ".sid" file format  {#sid-file-format}
 
 ".sid" files are used to persist and publish SIDs assigned to the different
-YANG items of a specific YANG module.
+YANG items of a specific YANG module. In a very simplistic view,
+the ".sid" file defines a mapping from SIDs to NIDs.
 
 It has the following structure:
 


### PR DESCRIPTION
During the discussion at WG, we use term NID, try to have it also in the document.